### PR TITLE
Padronizando padrao de envio do response enviado pelo backend

### DIFF
--- a/crm/Filters/ApiResponseWrapperFilter.cs
+++ b/crm/Filters/ApiResponseWrapperFilter.cs
@@ -1,0 +1,37 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace Filters
+{
+    public class ApiResponseWrapperFilter : IActionFilter
+    {
+        public void OnActionExecuting(ActionExecutingContext context)
+        {
+        }
+
+        public void OnActionExecuted(ActionExecutedContext context)
+        {
+            if (context.Result is ObjectResult objectResult)
+            {
+                if (objectResult.StatusCode >= 200 && objectResult.StatusCode < 300)
+                {
+                    context.Result = new ObjectResult(new { success = true, data = objectResult.Value })
+                    {
+                        StatusCode = objectResult.StatusCode
+                    };
+                }
+                else
+                {
+                    context.Result = new ObjectResult(new { success = false, error = objectResult.Value })
+                    {
+                        StatusCode = objectResult.StatusCode
+                    };
+                }
+            }
+            else if (context.Result is EmptyResult)
+            {
+                context.Result = new ObjectResult(new { success = true }) { StatusCode = 200 };
+            }
+        }
+    }
+}

--- a/crm/Program.cs
+++ b/crm/Program.cs
@@ -26,6 +26,10 @@ builder.Services.Configure<FormOptions>(options =>
 });
 
 builder.Services.AddControllers();
+builder.Services.AddControllers(options =>
+{
+    options.Filters.Add<Filters.ApiResponseWrapperFilter>();
+});
 builder.Services.AddEndpointsApiExplorer();
 
 builder.Services.AddSwaggerGen(c =>


### PR DESCRIPTION
[#14 Padronizar envio das respostas ](https://github.com/Projeto-integrador-tads2/api/issues/14)
Padronizando envio das respostas enviadas pelo backend

Ex:
"success": true OU false